### PR TITLE
Ensure scripts run in their own directory

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Ensure the script runs in its own directory
+cd "$(dirname "$0")" || exit 1
+
 echo "Setting up Bedrock server environment..."
 
 # Step 1: Update packages and install necessary tools

--- a/src/box64.sh
+++ b/src/box64.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Ensure the script runs in its own directory
+cd "$(dirname "$0")" || exit 1
+
 # Function to remove existing Box64 sources and keyring
 remove_existing_sources() {
     if [ -f /etc/apt/sources.list.d/box64.list ]; then

--- a/src/minecraft_version.sh
+++ b/src/minecraft_version.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Ensure the script runs in its own directory
+cd "$(dirname "$0")" || exit 1
+
 # Function to fetch the latest release or preview version
 fetch_version() {
     local pattern=$1


### PR DESCRIPTION
This pull request ensures that each script runs from its own directory to avoid potential issues with relative paths. The change was applied consistently across multiple scripts.

Directory context enforcement:

* [`setup.sh`](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R3-R5): Added a command to change the working directory to the script's directory at the start of the script.
* [`src/box64.sh`](diffhunk://#diff-c0fdfc8d2beb6873c6ac4275d26b3b39b545d2fd4d88eca3311aec18b26207e9R3-R5): Added a command to change the working directory to the script's directory at the start of the script.
* [`src/minecraft_version.sh`](diffhunk://#diff-4b353a8087963340cc8a5d8b2bb85fb6156a77362a0a70a11153715d8c62d5e5R3-R5): Added a command to change the working directory to the script's directory at the start of the script.