### PR TITLE
Feature/option7 delete instance

### DIFF
--- a/src/bedrock_server_manager.sh
+++ b/src/bedrock_server_manager.sh
@@ -203,6 +203,24 @@ view_instance_details() {
     echo "-------------------------"
 }
 
+# Function to delete an existing instance
+delete_instance() {
+    local instance_dir="$INSTANCES_DIR/$1"
+    if [ ! -d "$instance_dir" ]; then
+        echo "Error: Instance $1 does not exist."
+        exit 1
+    fi
+
+    read -p "Are you sure you want to delete the instance '$1'? This action cannot be undone. [y/N]: " confirm
+    if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+        echo "Operation canceled."
+        exit 0
+    fi
+
+    rm -rf "$instance_dir" || { echo "Error: Failed to delete the instance."; exit 1; }
+    echo "Instance '$1' deleted successfully."
+}
+
 # Main menu for user interaction
 echo "Choose an option:"
 echo "1. Create a new instance"
@@ -211,10 +229,11 @@ echo "3. Delete an existing instance and create a new one with the latest or spe
 echo "4. Create a backup of an existing instance"
 echo "5. Restore a backup"
 echo "6. View details of an existing instance"
-read -p "Enter your choice [1-6]: " option
+echo "7. Delete an existing instance"
+read -p "Enter your choice [1-7]: " option
 
 # Handle user input
-if [[ "$option" -ne 1 && "$option" -ne 2 && "$option" -ne 3 && "$option" -ne 4 && "$option" -ne 5 && "$option" -ne 6 ]]; then
+if [[ "$option" -ne 1 && "$option" -ne 2 && "$option" -ne 3 && "$option" -ne 4 && "$option" -ne 5 && "$option" -ne 6 && "$option" -ne 7 ]]; then
     echo "Invalid option."
     exit 1
 fi
@@ -323,6 +342,18 @@ elif [ "$option" -eq 6 ]; then
         exit 1
     fi
     view_instance_details "$instance_dir"
+    exit 0
+
+    elif [ "$option" -eq 7 ]; then
+    if ! list_instances; then
+        exit 1
+    fi
+    read -p "Enter the name of the instance to delete: " instance_dir
+    if [ ! -d "$INSTANCES_DIR/$instance_dir" ]; then
+        echo "Error: Instance $instance_dir does not exist."
+        exit 1
+    fi
+    delete_instance "$instance_dir"
     exit 0
 else
     if ! list_instances; then

--- a/src/bedrock_server_manager.sh
+++ b/src/bedrock_server_manager.sh
@@ -230,10 +230,11 @@ echo "4. Delete an existing instance"
 echo "5. View details of an existing instance"
 echo "6. Create a backup of an existing instance"
 echo "7. Restore a backup"
-read -p "Enter your choice [1-7]: " option
+echo "8. Delete a backup"
+read -p "Enter your choice [1-8]: " option
 
 # Handle user input
-if [[ "$option" -ne 1 && "$option" -ne 2 && "$option" -ne 3 && "$option" -ne 4 && "$option" -ne 5 && "$option" -ne 6 && "$option" -ne 7 ]]; then
+if [[ "$option" -ne 1 && "$option" -ne 2 && "$option" -ne 3 && "$option" -ne 4 && "$option" -ne 5 && "$option" -ne 6 && "$option" -ne 7 && "$option" -ne 8 ]]; then
     echo "Invalid option."
     exit 1
 fi
@@ -385,6 +386,41 @@ elif [ "$option" -eq 7 ]; then
     else
         echo "Error: Backup restoration failed. Target directory is empty."
         exit 1
+    fi
+
+    elif [ "$option" -eq 8 ]; then
+    # Delete backups
+    if [ ! -d "$BACKUP_DIR" ]; then
+        echo "Error: The 'backups' folder does not exist."
+        exit 1
+    fi
+
+    backups_count=$(ls "$BACKUP_DIR"/*.tar.gz 2>/dev/null | wc -l)
+    if [ "$backups_count" -eq 0 ]; then
+        echo "No backups found in the 'backups' folder."
+        exit 1
+    fi
+
+    echo "Available backups:"
+    ls "$BACKUP_DIR"/*.tar.gz
+    read -p "Enter the name of the backup file to delete (e.g., your_backup.tar.gz), or type 'all' to delete all backups: " backup_name
+
+    if [ "$backup_name" == "all" ]; then
+        read -p "Are you sure you want to delete all backups? This action cannot be undone. [y/N]: " confirm
+        if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+            echo "Operation canceled."
+            exit 0
+        fi
+        rm -f "$BACKUP_DIR"/*.tar.gz || { echo "Error: Failed to delete backups."; exit 1; }
+        echo "All backups have been deleted."
+    else
+        backup_file="$BACKUP_DIR/$backup_name"
+        if [ ! -f "$backup_file" ]; then
+            echo "Error: Backup file '$backup_name' does not exist."
+            exit 1
+        fi
+        rm -f "$backup_file" || { echo "Error: Failed to delete the backup file."; exit 1; }
+        echo "Backup '$backup_name' has been deleted."
     fi
 else
     echo "Invalid option."


### PR DESCRIPTION
This pull request enhances the `bedrock_server_manager.sh` script by adding new functionality for managing instances and backups, reorganizing menu options, and improving user interaction. The most significant changes include the addition of new features for deleting instances and backups, reordering menu options, and updating references to these options throughout the script.

### New Features:
* **Delete Instances**: Added a `delete_instance` function to allow users to delete existing instances with confirmation prompts. Integrated this feature into the main menu as Option 4.
* **Delete Backups**: Added functionality to delete individual or all backups with confirmation prompts. Integrated this feature into the main menu as Option 8.

### Menu Reorganization:
* Reordered main menu options to improve logical grouping and usability. For example, "Delete an existing instance" is now Option 4, and "Delete a backup" is Option 8.

### Updates to References:
* Updated references to menu options in error messages and prompts to align with the new menu structure. For example, backup-related options now refer to Options 6 and 7 instead of 4 and 5.